### PR TITLE
Fix #13 by setting extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "Education",
     "Other"
   ],
+  "extensionKind": [
+    "workspace"
+  ],
   "keywords": [
     "python",
     "jupyter",


### PR DESCRIPTION
Fixes #13

Explicitly sets the extensionKind to workspace in package.json. This ensures that the extension runs where the workspace is located (e.g., on a remote server when using VS Code Remote) rather than on the local UI side,  which is required for proper access to the project's Python environment and Jupytext executable.