### PR TITLE
Fix race condition in runCommand by awaiting close instead of exit

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -88,7 +88,7 @@ export async function runCommand(cmdArgs: string[], cwd?: string): Promise<strin
       console.error(msg)
       return reject(stderr)
     })
-    proc.on("exit", (code: number) => {
+    proc.on("close", (code: number) => {
       stderr = stderr.trim()
       stdout = stdout.trim()
       let msg = `Exit code '${code}' during '${cmdStr}'`
@@ -105,21 +105,6 @@ export async function runCommand(cmdArgs: string[], cwd?: string): Promise<strin
       console.debug(msg)
       resolve(stdout)
     })
-    // Not sure if needed, we already get the output in the proc.on("exit")
-    // This seems duplicate
-    // proc.on("close", () => {
-    //     stdout = stdout.trim()
-    //     stderr = stderr.trim()
-    //     let msg = `Closed '${cmdStr}'`
-    //     if (stderr.length > 0) {
-    //         msg += `\n(stderr): ${stderr}`
-    //     }
-    //     if (stdout.length > 0) {
-    //         msg += `\n(stdout): ${stdout}`
-    //     }
-    //     console.debug(msg)
-    //     resolve(stdout)
-    // })
   })
 }
 


### PR DESCRIPTION
Fixes #13 

runCommand currently resolves its promise on the child process exit event. In Node.js, exit triggers when the OS process terminates, but it does not guarantee that stdio streams have been fully flushed to the parent.

This creates a race condition in  execution environments like remote SSH, causing the extension to miss the output of short-lived commands like the Python path check. I confirmed this was the root cause because the issue disappears when wrapping the interpreter in a script that sleeps briefly to keep the pipe open:

```Bash
#!/bin/bash
# Minimal mitigation script
exec /path/to/python "$@"
sleep 0.5
```
This PR switches the listener to the close event, which Node.js guarantees is only emitted after stdio streams are fully closed and flushed, ensuring complete output capture without workarounds.