### PR TITLE
Support ms-python.vscode-python-envs for Python environment discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.5 2026-03-24
+
+- Support automatic Python discovery via the [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (`ms-python.vscode-python-envs`), the new official Microsoft extension for managing Python environments. It is tried before `ms-python.python` and re-validates Jupytext when the active environment changes.
+
 ## 1.4.4 2026-03-02
 
 - Support ${userHome} and ${env:VAR_NAME} in `jupytextSync.pythonExecutable` setting by [@alxhslm](https://github.com/alxhslm).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The extension activates when VS Code has finished starting up (`onStartupFinishe
 
 - **Python**: You need a Python installation.
 - **Jupytext**: The `jupytext` Python package must be installed in the Python environment used by the extension.
-- **VS Code Microsoft Python Extension (Recommended)**: For the best experience with automatic Python environment detection, it is recommended to have the Microsoft Python extension installed ([open in VSCode](vscode:extension/ms-python.python) / [open on marketplace](https://marketplace.visualstudio.com/items?itemName=ms-python.python)).
+- **VS Code Python Extension (Recommended)**: For the best experience with automatic Python environment detection, it is recommended to have one of the following Microsoft extensions installed:
+  - [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) (`ms-python.vscode-python-envs`) — the new official extension for managing Python environments ([open in VSCode](vscode:extension/ms-python.vscode-python-envs))
+  - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) (`ms-python.python`) — the classic Microsoft Python extension ([open in VSCode](vscode:extension/ms-python.python))
 
 ## Features
 
@@ -54,7 +56,7 @@ This extension solves several common annoyances and provides handy features for 
   - Toggle cells to raw format and back to default code. Keyboard shortcuts available.
 - **Compact Notebook Layout**: A command to apply a suggested VSCode settings for a more compact notebook layout, similar to traditional Jupyter interfaces.
 - **Python Interpreter Flexibility**:
-  - Attempts are made to automatically discover Python executables that are able to invoke Jupytext. If the Microsoft Python extension is installed ([open in VSCode](vscode:extension/ms-python.python) / [open on marketplace](https://marketplace.visualstudio.com/items?itemName=ms-python.python)), its selected interpreter and other discovered environments (e.g., `venv`, `conda`) are considered.
+  - Attempts are made to automatically discover Python executables that are able to invoke Jupytext. The following sources are tried in order: the [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (if installed), the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) extension (if installed), and `python`/`python3` on your `$PATH`. The active environment and all discovered environments (e.g., `venv`, `conda`) are considered. Jupytext is re-validated automatically when the active Python environment changes.
   - Allows you to configure a custom Python executable path for `jupytext` if needed (via the `jupytextSync.pythonExecutable` setting).
   - You can use the "**Jupytext: Locate Python and Jupytext**" command or check the extension logs ("**Jupytext: Show Jupytext Sync Logs**" command) to see which Python environment is being used.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jupytext-sync",
   "displayName": "Jupytext Sync",
   "description": "Pair and Auto Sync Jupyter Notebooks via Jupytext",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "engines": {
     "vscode": "^1.72.0"
   },
@@ -71,7 +71,7 @@
         "jupytextSync.pythonExecutable": {
           "type": "string",
           "default": "",
-          "markdownDescription": "The path to the Python executable used to invoke [`jupytext`](https://jupytext.readthedocs.io).\n\nJupytext Sync requires a Python executable to be installed along with the `jupytext` package.\n\n**Automatic discovery:** If not specified in your User/Workspace settings, Jupytext Sync attempts to find a Python executable that has `jupytext` installed. If you have the Microsoft Python extension installed ([open in VSCode](vscode:extension/ms-python.python) / [open on marketplace](https://marketplace.visualstudio.com/items?itemName=ms-python.python)), Jupytext will be able to detect Python virtual environments (e.g., `venv`, `conda`, `virtualenv`, etc.), besides the `python` and `python3` from your `$PATH`. If more than one Python executable is found, the one that provides the highest version of `jupytext` is selected.\nTip: If you would like to know if Jupytext Sync found your python executable(s), you can check the logs in the [_Jupytext Sync Output_](command:jupytextSync.showLogs) panel.\n\n**Manual override:** If the automatic discovery failed or you want to use a different Python executable, you can specify the path to the Python executable.\nAlternatively, you can set it to, e.g., `python3` if you want to use the `python3` from your `$PATH`. For this to work as expected, you might have to launch VSCode from terminal, otherwise `$PATH` might differ from what you are used to in the terminal. If you use a virtual python environment, you have to activate it first.\n\n**Variables:** `${workspaceFolder}` is replaced with the workspace folder path, `${userHome}` with the user's home directory, `${env:VAR_NAME}` with the value of environment variable `VAR_NAME`.",
+          "markdownDescription": "The path to the Python executable used to invoke [`jupytext`](https://jupytext.readthedocs.io).\n\nJupytext Sync requires a Python executable to be installed along with the `jupytext` package.\n\n**Automatic discovery:** If not specified in your User/Workspace settings, Jupytext Sync attempts to find a Python executable that has `jupytext` installed. The following sources are tried in order:\n1. [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (`ms-python.vscode-python-envs`) — the new official Microsoft extension for managing Python environments ([open in VSCode](vscode:extension/ms-python.vscode-python-envs))\n2. [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) extension (`ms-python.python`) — the classic Microsoft Python extension ([open in VSCode](vscode:extension/ms-python.python))\n3. `python` and `python3` from your `$PATH`\n\nIf more than one Python executable is found, the one that provides the highest version of `jupytext` is selected.\nTip: If you would like to know if Jupytext Sync found your python executable(s), you can check the logs in the [_Jupytext Sync Output_](command:jupytextSync.showLogs) panel.\n\n**Manual override:** If the automatic discovery failed or you want to use a different Python executable, you can specify the path to the Python executable.\nAlternatively, you can set it to, e.g., `python3` if you want to use the `python3` from your `$PATH`. For this to work as expected, you might have to launch VSCode from terminal, otherwise `$PATH` might differ from what you are used to in the terminal. If you use a virtual python environment, you have to activate it first.\n\n**Variables:** `${workspaceFolder}` is replaced with the workspace folder path, `${userHome}` with the user's home directory, `${env:VAR_NAME}` with the value of environment variable `VAR_NAME`.",
           "order": 0
         },
         "jupytextSync.deleteOnNotebookClose": {
@@ -470,8 +470,8 @@
     "@typescript-eslint/parser": "^8.7.0",
     "@vscode/vsce": "^3.3.2",
     "eslint": "^9.13.0",
-    "typescript": "^5.6.3",
-    "ovsx": "^0.10.2"
+    "ovsx": "^0.10.2",
+    "typescript": "^5.6.3"
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import {
   locatePythonAndJupytext,
 } from "./jupytext"
 import {PairedNotebookEditorProvider} from "./pairedNotebookEditor"
+import {getNewPythonEnvsApi} from "./pythonEnvironmentsApi"
 
 // Store disposables for event handlers so we can manage them
 let disposables: vscode.Disposable[] = []
@@ -82,6 +83,9 @@ export async function activate(context: vscode.ExtensionContext) {
   // Validate Python and Jupytext on extension activation so that we have an updated
   // list of supported extensions
   await validatePythonAndJupytext()
+
+  // Subscribe to Python environment changes from ms-python.vscode-python-envs
+  subscribeToNewPythonEnvsChanges(context)
 
   // Initial setup of handlers based on current configuration
   await updateEventHandlers(context)
@@ -359,6 +363,38 @@ async function setSuggestedCompactNotebookLayout() {
     await setConfig(key, value, vscode.ConfigurationTarget.Global)
   }
   vscode.window.showInformationMessage("Suggested compact notebook layout settings applied.")
+}
+
+async function subscribeToNewPythonEnvsChanges(context: vscode.ExtensionContext) {
+  const api = await getNewPythonEnvsApi()
+  if (!api) {
+    return
+  }
+  try {
+    // Single shared timer: both events trigger the same action, so one debounce covers both.
+    // Delay trade-off: short = snappier feedback; long = fewer redundant re-validations during
+    // burst discovery at startup. 500 ms is below the threshold of noticeable UI lag.
+    const DEBOUNCE_MS = 500
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined
+    const scheduleRevalidate = (reason: string) => {
+      clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(async () => {
+        getJConsole().appendLine(`${reason}, re-validating...`)
+        await validatePythonAndJupytext()
+      }, DEBOUNCE_MS)
+    }
+
+    context.subscriptions.push(
+      api.onDidChangeEnvironment(() =>
+        scheduleRevalidate("Python environment changed (ms-python.vscode-python-envs)"),
+      ),
+      api.onDidChangeEnvironments(() =>
+        scheduleRevalidate("Python environments list changed (ms-python.vscode-python-envs)"),
+      ),
+    )
+  } catch (ex) {
+    getJConsole().appendLine(`Failed to subscribe to Python environment changes: ${ex}`)
+  }
 }
 
 export function deactivate() {

--- a/src/python.ts
+++ b/src/python.ts
@@ -3,6 +3,7 @@ import {spawn} from "child_process"
 import * as vscode from "vscode"
 import {PythonExtension} from "@vscode/python-extension"
 import {getJConsole, config} from "./constants"
+import {getNewPythonEnvsApi} from "./pythonEnvironmentsApi"
 
 export function getPythonFromConfig(): string | undefined {
   let pythonExecutable = config().get<string>("pythonExecutable") ?? undefined
@@ -162,9 +163,66 @@ function getSystemPythonPaths() {
   return ["python", "python3"]
 }
 
+async function getPythonPathsViaNewPythonEnvs(): Promise<string[]> {
+  const msgPrefix = "Skipping Python discovery via ms-python.vscode-python-envs extension"
+  const api = await getNewPythonEnvsApi()
+  if (!api) {
+    getJConsole().appendLine(`${msgPrefix}: not installed.`)
+    return []
+  }
+  try {
+    const paths: string[] = []
+    const addEnvPath = (env: {execInfo?: {run?: {executable?: string}}; error?: string}) => {
+      const exe = env.execInfo?.run?.executable
+      if (exe && !env.error && !paths.includes(exe)) {
+        paths.push(exe)
+      }
+    }
+    // Prefer the selected environment for the current workspace folder (highest signal)
+    const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri
+    if (workspaceUri) {
+      const active = await api.getEnvironment(workspaceUri)
+      if (active) {
+        getJConsole().appendLine(
+          `ms-python.vscode-python-envs: workspace active env: ${active.execInfo?.run?.executable ?? "(no executable)"}${active.error ? ` [broken: ${active.error}]` : ""}`,
+        )
+        addEnvPath(active)
+      } else {
+        getJConsole().appendLine("ms-python.vscode-python-envs: no active env set for workspace.")
+      }
+    }
+    // Fall back to the globally-selected environment (useful with no workspace or single-file mode)
+    const globalActive = await api.getEnvironment(undefined)
+    if (globalActive) {
+      getJConsole().appendLine(
+        `ms-python.vscode-python-envs: global active env: ${globalActive.execInfo?.run?.executable ?? "(no executable)"}${globalActive.error ? ` [broken: ${globalActive.error}]` : ""}`,
+      )
+      addEnvPath(globalActive)
+    }
+    // Then include all other discovered environments, skipping broken ones
+    const all = await api.getEnvironments("all")
+    getJConsole().appendLine(
+      `ms-python.vscode-python-envs: ${all.length} environment(s) discovered total, ${all.filter((e) => e.error).length} broken (skipped).`,
+    )
+    for (const env of all) {
+      addEnvPath(env)
+    }
+    getJConsole().appendLine(
+      `ms-python.vscode-python-envs: resolved ${paths.length} candidate path(s): ${paths.join(", ") || "(none)"}`,
+    )
+    return paths
+  } catch (ex) {
+    const msg = `${msgPrefix}: failed: ${ex}`
+    console.error(msg, ex)
+    getJConsole().appendLine(msg)
+    return []
+  }
+}
+
 export async function getPythonPaths() {
   const pythonPath = config("python").get<string>("defaultInterpreterPath")
   const pythonPaths = new Set([
+    ...(await getPythonPathsViaNewPythonEnvs()),
     ...(await getPythonPathsViaMsPython()),
     ...getSystemPythonPaths(),
     ...(pythonPath ? [pythonPath] : []),

--- a/src/pythonEnvironmentsApi.ts
+++ b/src/pythonEnvironmentsApi.ts
@@ -1,0 +1,58 @@
+// Minimal type definitions for the ms-python.vscode-python-envs extension API.
+// Sourced from: https://github.com/microsoft/vscode-python-environments (pythonEnvironmentsApi/src/main.ts)
+// The @vscode/python-environments npm package is not yet published; this is a local copy.
+import * as vscode from "vscode"
+
+export interface PythonCommandRunConfiguration {
+  executable: string
+  args?: string[]
+}
+
+export interface PythonEnvironmentExecutionInfo {
+  run: PythonCommandRunConfiguration
+  activatedRun?: PythonCommandRunConfiguration
+}
+
+export interface PythonEnvironmentInfo {
+  readonly name: string
+  readonly displayName: string
+  readonly version: string
+  readonly execInfo: PythonEnvironmentExecutionInfo
+  readonly error?: string
+}
+
+export interface PythonEnvironment extends PythonEnvironmentInfo {
+  readonly envId: {readonly id: string}
+}
+
+export type DidChangeEnvironmentEventArgs = {
+  readonly uri: vscode.Uri | undefined
+  readonly old: PythonEnvironment | undefined
+  readonly new: PythonEnvironment | undefined
+}
+
+export type DidChangeEnvironmentsEventArgs = {
+  kind: "add" | "remove"
+  environment: PythonEnvironment
+}[]
+
+export interface PythonEnvironmentApi {
+  getEnvironments(scope: vscode.Uri | "all" | "global"): Promise<PythonEnvironment[]>
+  getEnvironment(scope: vscode.Uri | undefined): Promise<PythonEnvironment | undefined>
+  onDidChangeEnvironment: vscode.Event<DidChangeEnvironmentEventArgs>
+  onDidChangeEnvironments: vscode.Event<DidChangeEnvironmentsEventArgs>
+}
+
+let _api: PythonEnvironmentApi | undefined
+
+export async function getNewPythonEnvsApi(): Promise<PythonEnvironmentApi | undefined> {
+  if (_api) {
+    return _api
+  }
+  const ext = vscode.extensions.getExtension<PythonEnvironmentApi>("ms-python.vscode-python-envs")
+  if (!ext) {
+    return undefined
+  }
+  _api = ext.isActive ? ext.exports : await ext.activate()
+  return _api
+}


### PR DESCRIPTION
## Summary

- Adds support for the [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (`ms-python.vscode-python-envs`) as a Python discovery source, tried before `ms-python.python`
- Prefers the active workspace environment, falls back to the global active environment, then includes all other discovered environments
- Skips broken environments (those with an `error` field) before spawning subprocesses
- Subscribes to `onDidChangeEnvironment` and `onDidChangeEnvironments` with a shared 500 ms debounce to re-validate Jupytext when the active environment changes
- Updates README and `pythonExecutable` setting description to document all three discovery sources in priority order
- Bumps version to 1.4.5

## Test plan

- [x] With `ms-python.vscode-python-envs` installed: Output → Jupytext Sync shows `ms-python.vscode-python-envs: resolved N candidate path(s): ...`
- [x] With only `ms-python.python` installed: fallback works as before
- [x] With neither extension installed: `python`/`python3` PATH fallback works
- [x] Change active Python environment in the Python Environments UI → Jupytext re-validates automatically
- [x] Broken environments (with `error` field) are skipped and not probed

🤖 Generated with [Claude Code](https://claude.com/claude-code)